### PR TITLE
install: filter args from names

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -8,8 +8,8 @@ const { checkExistence, npmExists } = require('./helpers');
 
 function filterArgs() {
   // remove node, path, and command args
-  const args = process.argv.slice(3);
-  let names = args.filter(name => name[0] !== '-');
+  const args = process.argv.filter(word => word[0] !== '-');
+  const names = args.slice(3);
   return names;
 }
 


### PR DESCRIPTION
Fixes #9. Tested with and without `--prefix` flag. Just cleans out the `--...` args _before_ trimming command and path to return _just_ the plug-in names.